### PR TITLE
Add default timeout for more safe asynchronouse coding

### DIFF
--- a/CombineAsync/Classes/Sequence+Extensions.swift
+++ b/CombineAsync/Classes/Sequence+Extensions.swift
@@ -52,11 +52,11 @@ extension Sequence {
     /// It will run asynchronously and throwing error if one of the element is failing in the given async closure.
     /// It will still retain the original order of the element regardless of the order of mapping time completion
     /// - Parameters:
-    ///   - timeout: timeout in second
+    ///   - timeout: timeout in second, by default 30 seconds
     ///   - mapper: A mapping async closure. `mapper` accepts an element of this sequence as its parameter
     ///             and returns a transformed value of the same or of a different type asynchronously.
     /// - Returns: An array containing the transformed elements of this sequence
-    public func asyncMap<Mapped>(timeout: TimeInterval = 0, _ mapper: @escaping (Element) async throws -> Mapped) async throws -> [Mapped] {
+    public func asyncMap<Mapped>(timeout: TimeInterval = 30, _ mapper: @escaping (Element) async throws -> Mapped) async throws -> [Mapped] {
         try await convertToIndexedFutures(mapper)
             .sinkAsynchronously(timeout: timeout)
             .sorted { $0.index < $1.index }
@@ -68,11 +68,11 @@ extension Sequence {
     /// It will run asynchronously and throwing error if one of the element is failing in the given async closure.
     /// It will still retain the original order of the element regardless of the order of mapping time completion
     /// - Parameters:
-    ///   - timeout: timeout in second
+    ///   - timeout: timeout in second, by default 30 seconds
     ///   - mapper: A mapping async closure. `mapper` accepts an element of this sequence as its parameter
     ///             and returns an optional transformed value of the same or of a different type asynchronously.
     /// - Returns: An array containing the transformed elements of this sequence
-    public func asyncCompactMap<Mapped>(timeout: TimeInterval = 0, _ mapper: @escaping (Element) async throws -> Mapped?) async throws -> [Mapped] {
+    public func asyncCompactMap<Mapped>(timeout: TimeInterval = 30, _ mapper: @escaping (Element) async throws -> Mapped?) async throws -> [Mapped] {
         try await convertToIndexedFutures(mapper)
             .sinkAsynchronously(timeout: timeout)
             .sorted { $0.index < $1.index }

--- a/Example/Tests/PublisherAutoReleaseSpec.swift
+++ b/Example/Tests/PublisherAutoReleaseSpec.swift
@@ -56,7 +56,7 @@ class PublisherAutoReleaseSpec: QuickSpec {
             var retaining: RetainingObject? = RetainingObject()
             var completion: Subscribers.Completion<TestError>?
             var value: Int?
-            let cancellable = subject.autoReleaseSink(retainedTo: retaining) { comp in
+            let cancellable = subject.autoReleaseSink(retainedTo: retaining!) { comp in
                 completion = comp
             } receiveValue: { val in
                 value = val

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ CombineAsync is available under the MIT license. See the LICENSE file for more i
 You can convert any object that implements `Publisher` into Swift async with a single call:
 
 ```swift
+// implicitly await with 30 second timeout
 let result = await publisher.sinkAsynchronously()
 
-// or with timeout
+// or with timeout explicitly
 let timedResult = await publisher.sinkAsynchronously(timeout: 1)
 ```
 
@@ -122,6 +123,8 @@ publisher.autoReleaseSink { _ in
 }
 ```
 
+By default, it will auto release the closure after 30 seconds.
+
 If you want the closure to be released whenever some object is released, just pass the object:
 
 ```swift
@@ -135,7 +138,7 @@ publisher.autoReleaseSink(retainedTo: self) { _ in
 If you want the closure to be released using a timeout, just pass the timeout:
 
 ```swift
-publisher.autoReleaseSink(timeout: 30) { _ in
+publisher.autoReleaseSink(timeout: 60) { _ in
     // do something on completed
 } receiveValue: { 
     // do something on receive value
@@ -145,8 +148,8 @@ publisher.autoReleaseSink(timeout: 30) { _ in
 Whatever you pass, it will try to release the closure whenever one of the conditions is met:
 
 ```swift
-// the closure will be released after completion, or 30 second, or when self is released.
-publisher.autoReleaseSink(retainedTo: self, timeout: 30) { _ in
+// the closure will be released after completion, or 60 second, or when self is released.
+publisher.autoReleaseSink(retainedTo: self, timeout: 60) { _ in
     // do something on completed
 } receiveValue: { 
     // do something on receive value


### PR DESCRIPTION
Add 30 seconds as default timeout for:
- auto release sink
- sink async
- async map